### PR TITLE
Bump `etcd` chart to `6.0.0`

### DIFF
--- a/gardener/etcd-events.yaml
+++ b/gardener/etcd-events.yaml
@@ -16,7 +16,7 @@ spec:
   chart:
     spec:
       chart: etcd
-      version: 5.3.2
+      version: 6.0.0
       sourceRef:
         kind: HelmRepository
         name: gardener-community-charts

--- a/gardener/etcd.yaml
+++ b/gardener/etcd.yaml
@@ -16,7 +16,7 @@ spec:
   chart:
     spec:
       chart: etcd
-      version: 5.3.2
+      version: 6.0.0
       sourceRef:
         kind: HelmRepository
         name: gardener-community-charts

--- a/helmcharts/etcd/Chart.yaml
+++ b/helmcharts/etcd/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v3.5.2
+appVersion: v3.4.26
 description: Helm chart for etcd
 name: etcd
-version: 5.3.2
+version: 6.0.0

--- a/helmcharts/etcd/RELEASE.md
+++ b/helmcharts/etcd/RELEASE.md
@@ -1,5 +1,7 @@
 ## What's Changed
-* Optional .Values.backup.env appended to env vars of backup pod by @gesslein in https://github.com/gardener-community/etcd/pull/12
+* Downgrade to etcd 3.4.26, Upgrade to etcd-backup-restore 0.24.7 by @JensAc in https://github.com/gardener-community/etcd/pull/13
 
+## New Contributors
+* @JensAc made their first contribution in https://github.com/gardener-community/etcd/pull/13
 
-**Full Changelog**: https://github.com/gardener-community/etcd/compare/5.3.1...5.3.2
+**Full Changelog**: https://github.com/gardener-community/etcd/compare/5.3.2...6.0.0

--- a/helmcharts/etcd/templates/statefulset-etcd.yaml
+++ b/helmcharts/etcd/templates/statefulset-etcd.yaml
@@ -96,7 +96,7 @@ spec:
             cpu: {{ .Values.resources.limits.cpu | default "1000m" }}
             memory: {{ .Values.resources.limits.memory | default "2560Mi" }}
         volumeMounts:
-        - name: {{ .Values.name }}
+        - name: virtual-garden-{{ .Values.name }}
           mountPath: /var/etcd/data
         - name: etcd-bootstrap
           mountPath: /bootstrap
@@ -107,8 +107,7 @@ spec:
         - name: etcd-client-tls
           mountPath: /var/etcd/ssl/client
       - name: backup-restore
-        command:
-        - etcdbrctl
+        args:
         - server
         - --schedule={{ .Values.backup.schedule }}
         - --max-backups={{ .Values.backup.maxBackups }}
@@ -134,9 +133,10 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
-          limits:
-            cpu: 300m
-            memory: 1Gi
+        securityContext:
+          capabilities:
+            add:
+            - SYS_PTRACE
         env:
         - name: STORAGE_CONTAINER
           value: {{ .Values.backup.storageContainer }}
@@ -146,6 +146,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
         {{- if .Values.backup.storageProvider }}
         {{- if eq .Values.backup.storageProvider "ABS" }}
         - name: AZURE_APPLICATION_CREDENTIALS
@@ -166,7 +171,7 @@ spec:
         volumeMounts:
         - name: etcd-bootstrap
           mountPath: /bootstrap
-        - name: {{ .Values.name }}
+        - name: virtual-garden-{{ .Values.name }}
           mountPath: /var/etcd/data
         - name: ca-etcd
           mountPath: /var/etcd/ssl/ca
@@ -203,7 +208,7 @@ spec:
 {{- end }}
   volumeClaimTemplates:
   - metadata:
-      name: {{ .Values.name }}
+      name: virtual-garden-{{ .Values.name }}
     spec:
       accessModes:
       - "ReadWriteOnce"

--- a/helmcharts/etcd/values.yaml
+++ b/helmcharts/etcd/values.yaml
@@ -7,8 +7,8 @@ backup:
     storageProvider: ""
     volumeMounts: []
 images:
-    etcd: eu.gcr.io/gardener-project/gardener/etcd:v3.5.2
-    etcd-backup-restore: eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.19.0
+    etcd: eu.gcr.io/gardener-project/gardener/etcd:v3.4.26-3
+    etcd-backup-restore: eu.gcr.io/gardener-project/gardener/etcdbrctl:v0.24.7
 name: etcd
 resources:
     limits:


### PR DESCRIPTION
This reverts commit a5d5c391c7b253f5563f32cca4496828449b0552.

Yake Release Notes: https://yake.cloud/release-notes/v1.86/

The Yake `1.86` release upgrade its `etcd` chart from `5.3.2` to `6.0.0`. This performs an upgrade of `etcd` itself and a renaming of the `PVC`s. 

In the `ske-base` [PR](https://github.com/stackitcloud/ske-base/pull/1000) will be added a `postrenderers` function and resets the renaming.

The commit "Downgrade etcd Chart to 5.3.2" can be dropped with the next version 1.87.
This revert commit/PR can be dropped with the next version 1.87.