### PR TITLE
add postrenderers patch prevent etcd-renaming and use local chart with `secretStringData`

### DIFF
--- a/gardener/etcd-events.yaml
+++ b/gardener/etcd-events.yaml
@@ -67,13 +67,29 @@ spec:
       targetPath: tls.client.key
   postRenderers:
     - kustomize:
-        patchesStrategicMerge:
-          - kind: StatefulSet
-            apiVersion: apps/v1
-            metadata:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: StatefulSet
               name: etcd-events
-              namespace: garden
-            spec:
-              template:
-                spec:
-                  priorityClassName: gardener-kubernetes
+            patch: |-
+              - op: replace
+                path: /spec/template/spec/containers/0/volumeMounts/0/name
+                value: etcd-events
+              - op: replace
+                path: /spec/template/spec/containers/1/volumeMounts/1/name
+                value: etcd-events
+              - op: replace
+                path: /spec/volumeClaimTemplates/0/metadata/name
+                value: etcd-events
+          - patch: |-
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: etcd-events
+                namespace: garden
+              spec:
+                template:
+                  spec:
+                    priorityClassName: gardener-kubernetes

--- a/gardener/etcd.yaml
+++ b/gardener/etcd.yaml
@@ -15,11 +15,10 @@ spec:
     - name: certificates
   chart:
     spec:
-      chart: etcd
-      version: 6.0.0
+      chart: ./helmcharts/etcd
       sourceRef:
-        kind: HelmRepository
-        name: gardener-community-charts
+        kind: GitRepository
+        name: yake
         namespace: flux-system
       interval: 1m
   valuesFrom:

--- a/gardener/etcd.yaml
+++ b/gardener/etcd.yaml
@@ -65,13 +65,29 @@ spec:
       targetPath: tls.client.key
   postRenderers:
     - kustomize:
-        patchesStrategicMerge:
-          - kind: StatefulSet
-            apiVersion: apps/v1
-            metadata:
+        patches:
+          - target:
+              group: apps
+              version: v1
+              kind: StatefulSet
               name: etcd
-              namespace: garden
-            spec:
-              template:
-                spec:
-                  priorityClassName: gardener-kubernetes
+            patch: |-
+              - op: replace
+                path: /spec/template/spec/containers/0/volumeMounts/0/name
+                value: etcd
+              - op: replace
+                path: /spec/template/spec/containers/1/volumeMounts/1/name
+                value: etcd
+              - op: replace
+                path: /spec/volumeClaimTemplates/0/metadata/name
+                value: etcd
+          - patch: |-
+              apiVersion: apps/v1
+              kind: StatefulSet
+              metadata:
+                name: etcd
+                namespace: garden
+              spec:
+                template:
+                  spec:
+                    priorityClassName: gardener-kubernetes

--- a/helmcharts/etcd/templates/secret-etcd-backup.yaml
+++ b/helmcharts/etcd/templates/secret-etcd-backup.yaml
@@ -19,6 +19,8 @@ metadata:
   name: {{ .Values.name }}-backup
   namespace: {{ .Release.Namespace }}
 type: Opaque
+stringData:
+{{ toYaml .Values.backup.secretStringData | indent 2 }}
 data:
   {{- if eq .Values.backup.storageProvider "ABS" }}
   storageAccount: {{ index .Values.backup.secretData "storage-account" }}

--- a/helmcharts/etcd/values.yaml
+++ b/helmcharts/etcd/values.yaml
@@ -3,6 +3,7 @@ backup:
     maxBackups: 7
     schedule: 0 */24 * * *
     secretData: {}
+    secretStringData: {}
     storageContainer: ""
     storageProvider: ""
     volumeMounts: []


### PR DESCRIPTION
#### Prefixing of `etcd` PVCs
This change adds JSON-Patches to reset the renaming of the breaking change by YAKE 1.86. 

The prefix "virtual-garden-" will be removed from the PVCs.

`This change can be dropped, if we changed the names of our PVCs (quiet long downtime) or we deploy etcd differently.`

Please refer to our documentation: https://hedgedoc.ske.eu01.stackit.cloud/W4zDhnvqQDqnfYrkQ04BSQ

#### Breaking change on `etcd-backup-restore` v0.19

Additionally we needed a workaround to pass the env vars to our etcd backup. Due to the breaking change of `etcd-backup-restore` [v0.19](https://github.com/gardener/etcd-backup-restore/releases/tag/v0.19.0), we had to find a way to pass the credentials to the helm chart without using our way via ENV vars. We introduced the `secretStringData` as a method to pass it via in `ske-base` to this helm chart. Additionally, we moved the upstream chart to the local chart, because it isn't used in any way.

`This change can be dropped, whenever it is fixed upstream (by us).`