### PR TITLE
🐛 remove useless `.Values.backup.secretData` from Secret so the hash for etcd-backup doesn't change

### DIFF
--- a/helmcharts/etcd/templates/secret-etcd-backup.yaml
+++ b/helmcharts/etcd/templates/secret-etcd-backup.yaml
@@ -22,8 +22,6 @@ type: Opaque
 stringData:
 {{- toYaml .Values.backup.secretStringData | nindent 2 }}
 data:
-{{ toYaml .Values.backup.secretData | indent 2 }}
-
   {{- if eq .Values.backup.storageProvider "ABS" }}
   {{- if index .Values.backup.secretData "storage-account" }}
   storageAccount: {{ index .Values.backup.secretData "storage-account" }}


### PR DESCRIPTION
Before:
The commit-hash of etcd-backup would change (because of the empty line), which triggers a different hash for main garden etcd thus resulting in a restart